### PR TITLE
lightningnetwork/lndへの追従

### DIFF
--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -165,6 +165,8 @@ func (b *breachArbiter) Start() error {
 	// finished our responsibilities. If the removal is successful, we also
 	// remove the entry from our in-memory map, to avoid any further action
 	// for this channel.
+	// TODO(halseth): no need continue on IsPending once closed channels
+	// actually means close transaction is confirmed.
 	for _, chanSummary := range closedChans {
 		if chanSummary.IsPending {
 			continue

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -44,6 +44,10 @@ const (
 	defaultLitecoinTimeLockDelta = 576
 	defaultLitecoinStaticFeeRate = lnwallet.SatPerVByte(200)
 	defaultLitecoinDustLimit     = btcutil.Amount(54600)
+
+	// btcToLtcConversionRate is a fixed ratio used in order to scale up
+	// payments when running on the Litecoin chain.
+	btcToLtcConversionRate = 60
 )
 
 // defaultBtcChannelConstraints is the default set of channel constraints that are

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1673,12 +1673,12 @@ type ChannelCloseSummary struct {
 
 	// IsPending indicates whether this channel is in the 'pending close'
 	// state, which means the channel closing transaction has been
-	// broadcast, but not confirmed yet or has not yet been fully resolved.
-	// In the case of a channel that has been cooperatively closed, it will
-	// no longer be considered pending as soon as the closing transaction
-	// has been confirmed. However, for channel that have been force
-	// closed, they'll stay marked as "pending" until _all_ the pending
-	// funds have been swept.
+	// confirmed, but not yet been fully resolved. In the case of a channel
+	// that has been cooperatively closed, it will go straight into the
+	// fully resolved state as soon as the closing transaction has been
+	// confirmed. However, for channel that have been force closed, they'll
+	// stay marked as "pending" until _all_ the pending funds have been
+	// swept.
 	IsPending bool
 
 	// RemoteCurrentRevocation is the current revocation for their

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -154,7 +154,7 @@ func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
 func main() {
 	app := cli.NewApp()
 	app.Name = "lncli"
-	app.Version = fmt.Sprintf("%s commit=%s", "0.4.1", Commit)
+	app.Version = fmt.Sprintf("%s commit=%s", "0.4.2", Commit)
 	app.Usage = "control plane for your Lightning Network Daemon (lnd)"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/config.go
+++ b/config.go
@@ -353,42 +353,6 @@ func loadConfig() (*config, error) {
 	cfg.BitcoindMode.Dir = cleanAndExpandPath(cfg.BitcoindMode.Dir)
 	cfg.LitecoindMode.Dir = cleanAndExpandPath(cfg.LitecoindMode.Dir)
 
-	// Ensure that the user didn't attempt to specify negative values for
-	// any of the autopilot params.
-	if cfg.Autopilot.MaxChannels < 0 {
-		str := "%s: autopilot.maxchannels must be non-negative"
-		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, err
-	}
-	if cfg.Autopilot.Allocation < 0 {
-		str := "%s: autopilot.allocation must be non-negative"
-		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, err
-	}
-	if cfg.Autopilot.MinChannelSize < 0 {
-		str := "%s: autopilot.minchansize must be non-negative"
-		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, err
-	}
-	if cfg.Autopilot.MaxChannelSize < 0 {
-		str := "%s: autopilot.maxchansize must be non-negative"
-		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, err
-	}
-
-	// Ensure that the specified values for the min and max channel size
-	// don't are within the bounds of the normal chan size constraints.
-	if cfg.Autopilot.MinChannelSize < int64(minChanFundingSize) {
-		cfg.Autopilot.MinChannelSize = int64(minChanFundingSize)
-	}
-	if cfg.Autopilot.MaxChannelSize > int64(maxFundingAmount) {
-		cfg.Autopilot.MaxChannelSize = int64(maxFundingAmount)
-	}
-
 	// Setup dial and DNS resolution functions depending on the specified
 	// options. The default is to use the standard golang "net" package
 	// functions. When Tor's proxy is specified, the dial function is set to
@@ -533,6 +497,8 @@ func loadConfig() (*config, error) {
 		// Finally we'll register the litecoin chain as our current
 		// primary chain.
 		registeredChains.RegisterPrimaryChain(litecoinChain)
+		maxFundingAmount = maxLtcFundingAmount
+		maxPaymentMSat = maxLtcPaymentMSat
 
 	case cfg.Bitcoin.Active:
 		// Multiple networks can't be selected simultaneously.  Count
@@ -624,6 +590,42 @@ func loadConfig() (*config, error) {
 		// Finally we'll register the bitcoin chain as our current
 		// primary chain.
 		registeredChains.RegisterPrimaryChain(bitcoinChain)
+	}
+
+	// Ensure that the user didn't attempt to specify negative values for
+	// any of the autopilot params.
+	if cfg.Autopilot.MaxChannels < 0 {
+		str := "%s: autopilot.maxchannels must be non-negative"
+		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+	if cfg.Autopilot.Allocation < 0 {
+		str := "%s: autopilot.allocation must be non-negative"
+		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+	if cfg.Autopilot.MinChannelSize < 0 {
+		str := "%s: autopilot.minchansize must be non-negative"
+		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+	if cfg.Autopilot.MaxChannelSize < 0 {
+		str := "%s: autopilot.maxchansize must be non-negative"
+		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+
+	// Ensure that the specified values for the min and max channel size
+	// don't are within the bounds of the normal chan size constraints.
+	if cfg.Autopilot.MinChannelSize < int64(minChanFundingSize) {
+		cfg.Autopilot.MinChannelSize = int64(minChanFundingSize)
+	}
+	if cfg.Autopilot.MaxChannelSize > int64(maxFundingAmount) {
+		cfg.Autopilot.MaxChannelSize = int64(maxFundingAmount)
 	}
 
 	// Validate profile port number.

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -737,20 +737,5 @@ func (c *ChainArbitrator) SubscribeChannelEvents(
 	return watcher.SubscribeChannelEvents(), nil
 }
 
-// BeginCoopChanClose allows the initiator or responder to a cooperative
-// channel closure to signal to the ChainArbitrator that we're starting close
-// negotiation. The caller can use this context to allow the underlying chain
-// watcher to be prepared to act if *any* of the transactions that may
-// potentially be signed off on during fee negotiation are confirmed.
-func (c *ChainArbitrator) BeginCoopChanClose(chanPoint wire.OutPoint) (*CooperativeCloseCtx, error) {
-	watcher, ok := c.activeWatchers[chanPoint]
-	if !ok {
-		return nil, fmt.Errorf("unable to find watcher for: %v",
-			chanPoint)
-	}
-
-	return watcher.BeginCooperativeClose(), nil
-}
-
 // TODO(roasbeef): arbitration reports
 //  * types: contested, waiting for success conf, etc

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -392,11 +392,17 @@ func (c *ChainArbitrator) Start() error {
 	}
 
 	// Next, for each channel is the closing state, we'll launch a
-	// corresponding more restricted resolver.
+	// corresponding more restricted resolver, as we don't have to watch
+	// the chain any longer, only resolve the contracts on the confirmed
+	// commitment.
 	for _, closeChanInfo := range closingChannels {
 		// If this is a pending cooperative close channel then we'll
 		// simply launch a goroutine to wait until the closing
 		// transaction has been confirmed.
+		// TODO(halseth): can remove this since no coop close channels
+		// should be "pending close" after the recent changes. Keeping
+		// it for a bit in case someone with a coop close channel in
+		// the pending close state upgrades to the new commit.
 		if closeChanInfo.CloseType == channeldb.CooperativeClose {
 			go c.watchForChannelClose(closeChanInfo)
 

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/roasbeef/btcd/chaincfg"
-	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/roasbeef/btcd/txscript"
 	"github.com/roasbeef/btcd/wire"
 	"github.com/roasbeef/btcutil"
@@ -123,12 +122,6 @@ type chainWatcher struct {
 	// clientSubscriptions is a map that keeps track of all the active
 	// client subscriptions for events related to this channel.
 	clientSubscriptions map[uint64]*ChainEventSubscription
-
-	// possibleCloses is a map from cooperative closing transaction txid to
-	// a close summary that describes the nature of the channel closure.
-	// We'll use this map to keep track of all possible channel closures to
-	// ensure out db state is correct in the end.
-	possibleCloses map[chainhash.Hash]*channeldb.ChannelCloseSummary
 }
 
 // newChainWatcher returns a new instance of a chainWatcher for a channel given
@@ -158,7 +151,6 @@ func newChainWatcher(cfg chainWatcherConfig) (*chainWatcher, error) {
 		stateHintObfuscator: stateHint,
 		quit:                make(chan struct{}),
 		clientSubscriptions: make(map[uint64]*ChainEventSubscription),
-		possibleCloses:      make(map[chainhash.Hash]*channeldb.ChannelCloseSummary),
 	}, nil
 }
 
@@ -748,150 +740,6 @@ func (c *chainWatcher) dispatchContractBreach(spendEvent *chainntnfs.SpendDetail
 
 	log.Infof("Breached channel=%v marked pending-closed",
 		c.cfg.chanState.FundingOutpoint)
-
-	return nil
-}
-
-// CooperativeCloseCtx is a transactional object that's used by external
-// parties to initiate a cooperative closure negotiation. During the
-// negotiation, we sign multiple versions of a closing transaction, either of
-// which may be counter signed and broadcast by the remote party at any time.
-// As a result, we'll need to watch the chain to see if any of these confirm,
-// only afterwards will we mark the channel as fully closed.
-type CooperativeCloseCtx struct {
-	// potentialCloses is a channel will be used by the party negotiating
-	// the cooperative closure to send possible closing states to the chain
-	// watcher to ensure we detect all on-chain spends.
-	potentialCloses chan *channeldb.ChannelCloseSummary
-
-	// activeCloses keeps track of all the txid's that we're currently
-	// watching for.
-	activeCloses map[chainhash.Hash]struct{}
-
-	// watchCancel will be closed once *one* of the txid's in the map above
-	// is confirmed. This will cause all the lingering goroutines to exit.
-	watchCancel chan struct{}
-
-	watcher *chainWatcher
-
-	sync.Mutex
-}
-
-// BeginCooperativeClose should be called by the party negotiating the
-// cooperative closure before the first signature is sent to the remote party.
-// This will return a context that should be used to communicate possible
-// closing states so we can act on them.
-func (c *chainWatcher) BeginCooperativeClose() *CooperativeCloseCtx {
-	// We'll simply return a new close context that will be used be the
-	// caller to notify us of potential closes.
-	return &CooperativeCloseCtx{
-		potentialCloses: make(chan *channeldb.ChannelCloseSummary),
-		watchCancel:     make(chan struct{}),
-		activeCloses:    make(map[chainhash.Hash]struct{}),
-		watcher:         c,
-	}
-}
-
-// LogPotentialClose should be called by the party negotiating the cooperative
-// closure once they signed a new state, but *before* they transmit it to the
-// remote party. This will ensure that the chain watcher is able to log the new
-// state it should watch the chain for.
-func (c *CooperativeCloseCtx) LogPotentialClose(potentialClose *channeldb.ChannelCloseSummary) {
-	c.Lock()
-	defer c.Unlock()
-
-	// We'll check to see if we're already watching for a close of this
-	// channel, if so, then we'll exit early to avoid launching a duplicate
-	// goroutine.
-	if _, ok := c.activeCloses[potentialClose.ClosingTXID]; ok {
-		return
-	}
-
-	// Otherwise, we'll mark this txid as currently being watched.
-	c.activeCloses[potentialClose.ClosingTXID] = struct{}{}
-
-	// We'll take this potential close, and launch a goroutine which will
-	// wait until it's confirmed, then update the database state. When a
-	// potential close gets confirmed, we'll cancel out all other launched
-	// goroutines.
-	go func() {
-		confNtfn, err := c.watcher.cfg.notifier.RegisterConfirmationsNtfn(
-			&potentialClose.ClosingTXID, 1,
-			uint32(potentialClose.CloseHeight),
-		)
-		if err != nil {
-			log.Errorf("unable to register for conf: %v", err)
-			return
-		}
-
-		log.Infof("closeCtx: waiting for txid=%v to close "+
-			"ChannelPoint(%v) on chain", potentialClose.ClosingTXID,
-			c.watcher.cfg.chanState.FundingOutpoint)
-
-		select {
-		case confInfo, ok := <-confNtfn.Confirmed:
-			if !ok {
-				log.Errorf("notifier exiting")
-				return
-			}
-
-			log.Infof("closeCtx: ChannelPoint(%v) is fully closed, at "+
-				"height: %v", c.watcher.cfg.chanState.FundingOutpoint,
-				confInfo.BlockHeight)
-
-			close(c.watchCancel)
-
-			c.watcher.Lock()
-			for _, sub := range c.watcher.clientSubscriptions {
-				select {
-				case sub.CooperativeClosure <- struct{}{}:
-				case <-c.watcher.quit:
-				}
-			}
-			c.watcher.Unlock()
-
-			err := c.watcher.cfg.chanState.CloseChannel(potentialClose)
-			if err != nil {
-				log.Warnf("closeCtx: unable to update latest "+
-					"close for ChannelPoint(%v): %v",
-					c.watcher.cfg.chanState.FundingOutpoint, err)
-			}
-
-			err = c.watcher.cfg.markChanClosed()
-			if err != nil {
-				log.Errorf("closeCtx: unable to mark chan fully "+
-					"closed: %v", err)
-				return
-			}
-
-		case <-c.watchCancel:
-			log.Debugf("Exiting watch for close of txid=%v for "+
-				"ChannelPoint(%v)", potentialClose.ClosingTXID,
-				c.watcher.cfg.chanState.FundingOutpoint)
-
-		case <-c.watcher.quit:
-			return
-		}
-	}()
-}
-
-// Finalize should be called once both parties agree on a final transaction to
-// close out the channel. This method will immediately mark the channel as
-// pending closed in the database, then launch a goroutine to mark the channel
-// fully closed upon confirmation.
-func (c *CooperativeCloseCtx) Finalize(preferredClose *channeldb.ChannelCloseSummary) error {
-	chanPoint := c.watcher.cfg.chanState.FundingOutpoint
-
-	log.Infof("Finalizing chan close for ChannelPoint(%v)", chanPoint)
-
-	err := c.watcher.cfg.chanState.CloseChannel(preferredClose)
-	if err != nil {
-		log.Errorf("closeCtx: unable to close ChannelPoint(%v): %v",
-			chanPoint, err)
-		return err
-	}
-
-	go c.LogPotentialClose(preferredClose)
 
 	return nil
 }

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -85,8 +85,10 @@ type ChannelArbitratorConfig struct {
 
 	// ForceCloseChan should force close the contract that this attendant
 	// is watching over. We'll use this when we decide that we need to go
-	// to chain. The returned summary contains all items needed to
-	// eventually resolve all outputs on chain.
+	// to chain. It should in addition tell the switch to remove the
+	// corresponding link, such that we won't accept any new updates. The
+	// returned summary contains all items needed to eventually resolve all
+	// outputs on chain.
 	ForceCloseChan func() (*lnwallet.LocalForceCloseSummary, error)
 
 	// MarkCommitmentBroadcasted should mark the channel as the commitment
@@ -434,9 +436,10 @@ func (c *ChannelArbitrator) stateStep(triggerHeight uint32,
 		// Now that we have all the actions decided for the set of
 		// HTLC's, we'll broadcast the commitment transaction, and
 		// signal the link to exit.
-		//
-		// TODO(roasbeef): need to report to switch that channel is
-		// inactive, should close link
+
+		// We'll tell the switch that it should remove the link for
+		// this channel, in addition to fetching the force close
+		// summary needed to close this channel on chain.
 		closeSummary, err := c.cfg.ForceCloseChan()
 		if err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to "+

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -33,15 +33,6 @@ const (
 	// TODO(roasbeef): tune
 	msgBufferSize = 50
 
-	// maxFundingAmount is a soft-limit of the maximum channel size
-	// accepted within the Lightning Protocol Currently. This limit is
-	// currently defined in BOLT-0002, and serves as an initial
-	// precautionary limit while implementations are battle tested in the
-	// real world.
-	//
-	// TODO(roasbeef): add command line param to modify
-	maxFundingAmount = btcutil.Amount(1 << 24)
-
 	// minBtcRemoteDelay and maxBtcRemoteDelay is the extremes of the
 	// Bitcoin CSV delay we will require the remote to use for its
 	// commitment transaction. The actual delay we will require will be
@@ -64,6 +55,31 @@ const (
 	// minChanFundingSize is the smallest channel that we'll allow to be
 	// created over the RPC interface.
 	minChanFundingSize = btcutil.Amount(20000)
+
+	// maxBtcFundingAmount is a soft-limit of the maximum channel size
+	// currently accepted on the Bitcoin chain within the Lightning
+	// Protocol. This limit is defined in BOLT-0002, and serves as an
+	// initial precautionary limit while implementations are battle tested
+	// in the real world.
+	maxBtcFundingAmount = btcutil.Amount(1<<24) - 1
+
+	// maxLtcFundingAmount is a soft-limit of the maximum channel size
+	// currently accepted on the Litecoin chain within the Lightning
+	// Protocol.
+	maxLtcFundingAmount = maxBtcFundingAmount * btcToLtcConversionRate
+)
+
+var (
+	// maxFundingAmount is a soft-limit of the maximum channel size
+	// currently accepted within the Lightning Protocol. This limit is
+	// defined in BOLT-0002, and serves as an initial precautionary limit
+	// while implementations are battle tested in the real world.
+	//
+	// At the moment, this value depends on which chain is active. It is set
+	// to the value under the Bitcoin chain as default.
+	//
+	// TODO(roasbeef): add command line param to modify
+	maxFundingAmount = maxBtcFundingAmount
 )
 
 // reservationWithCtx encapsulates a pending channel reservation. This wrapper

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -64,7 +64,7 @@ const (
 	maxBtcFundingAmount = btcutil.Amount(1<<24) - 1
 
 	// maxMonaFundingAmount is a soft-limit of the maximum channel size
-	// currently accepted on the Litecoin chain within the Lightning
+	// currently accepted on the Monacoin chain within the Lightning
 	// Protocol.
 	maxMonaFundingAmount = maxBtcFundingAmount * btcToMonaConversionRate
 )

--- a/htlcswitch/hodl/config.go
+++ b/htlcswitch/hodl/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	FailOutgoing bool `long:"fail-outgoing" description:"Instructs the node to drop outgoing FAILs before applying them to the channel state"`
 
 	Commit bool `long:"commit" description:"Instructs the node to add HTLCs to its local commitment state and to open circuits for any ADDs, but abort before committing the changes"`
+
+	BogusSettle bool `long:"bogus-settle" description:"Instructs the node to settle back any incoming HTLC with a bogus preimage"`
 }
 
 // Mask extracts the flags specified in the configuration, composing a Mask from
@@ -51,6 +53,9 @@ func (c *Config) Mask() Mask {
 	}
 	if c.Commit {
 		flags = append(flags, Commit)
+	}
+	if c.BogusSettle {
+		flags = append(flags, BogusSettle)
 	}
 
 	// NOTE: The value returned here will only honor the configuration if

--- a/htlcswitch/hodl/flags.go
+++ b/htlcswitch/hodl/flags.go
@@ -51,6 +51,10 @@ const (
 	// Commit drops all HTLC after any outgoing circuits have been
 	// opened, but before the in-memory commitment state is persisted.
 	Commit
+
+	// BogusSettle attempts to settle back any incoming HTLC for which we
+	// are the exit node with a bogus preimage.
+	BogusSettle
 )
 
 // String returns a human-readable identifier for a given Flag.
@@ -72,6 +76,8 @@ func (f Flag) String() string {
 		return "FailOutgoing"
 	case Commit:
 		return "Commit"
+	case BogusSettle:
+		return "BogusSettle"
 	default:
 		return "UnknownHodlFlag"
 	}
@@ -98,6 +104,8 @@ func (f Flag) Warning() string {
 		msg = "will not update channel state with downstream FAIL"
 	case Commit:
 		msg = "will not commit pending channel updates"
+	case BogusSettle:
+		msg = "will settle HTLC with bogus preimage"
 	default:
 		msg = "incorrect hodl flag usage"
 	}

--- a/htlcswitch/hodl/mask_test.go
+++ b/htlcswitch/hodl/mask_test.go
@@ -67,6 +67,7 @@ var hodlMaskTests = []struct {
 			hodl.SettleOutgoing,
 			hodl.FailOutgoing,
 			hodl.Commit,
+			hodl.BogusSettle,
 		),
 		flags: map[hodl.Flag]struct{}{
 			hodl.ExitSettle:     {},
@@ -77,6 +78,7 @@ var hodlMaskTests = []struct {
 			hodl.SettleOutgoing: {},
 			hodl.FailOutgoing:   {},
 			hodl.Commit:         {},
+			hodl.BogusSettle:    {},
 		},
 	},
 }

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -130,10 +130,6 @@ type Peer interface {
 
 	// PubKey returns the serialize public key of the source peer.
 	PubKey() [33]byte
-
-	// Disconnect disconnects with peer if we have error which we can't
-	// properly handle.
-	Disconnect(reason error)
 }
 
 // ForwardingLog is an interface that represents a time series database which

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2206,6 +2206,16 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 
 			l.infof("settling %x as exit hop", pd.RHash)
 
+			// If the link is in hodl.BogusSettle mode, replace the
+			// preimage with a fake one before sending it to the
+			// peer.
+			if l.cfg.DebugHTLC &&
+				l.cfg.HodlMask.Active(hodl.BogusSettle) {
+				l.warnf(hodl.BogusSettle.Warning())
+				preimage = [32]byte{}
+				copy(preimage[:], bytes.Repeat([]byte{2}, 32))
+			}
+
 			// HTLC was successfully settled locally send
 			// notification about it remote peer.
 			l.cfg.Peer.SendMessage(&lnwire.UpdateFulfillHTLC{

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1396,6 +1396,8 @@ type mockPeer struct {
 	quit         chan struct{}
 }
 
+var _ Peer = (*mockPeer)(nil)
+
 func (m *mockPeer) SendMessage(msg lnwire.Message, sync bool) error {
 	if m.disconnected {
 		return fmt.Errorf("disconnected")
@@ -1412,8 +1414,6 @@ func (m *mockPeer) WipeChannel(*wire.OutPoint) error {
 }
 func (m *mockPeer) PubKey() [33]byte {
 	return [33]byte{}
-}
-func (m *mockPeer) Disconnect(reason error) {
 }
 
 var _ Peer = (*mockPeer)(nil)

--- a/htlcswitch/linkfailure.go
+++ b/htlcswitch/linkfailure.go
@@ -1,0 +1,95 @@
+package htlcswitch
+
+import "github.com/go-errors/errors"
+
+var (
+	// ErrLinkShuttingDown signals that the link is shutting down.
+	ErrLinkShuttingDown = errors.New("link shutting down")
+)
+
+// errorCode encodes the possible types of errors that will make us fail the
+// current link.
+type errorCode uint8
+
+const (
+	// ErrInternalError indicates that something internal in the link
+	// failed. In this case we will send a generic error to our peer.
+	ErrInternalError errorCode = iota
+
+	// ErrRemoteError indicates that our peer sent an error, prompting up
+	// to fail the link.
+	ErrRemoteError
+
+	// ErrSyncError indicates that we failed synchronizing the state of the
+	// channel with our peer.
+	ErrSyncError
+
+	// ErrInvalidUpdate indicates that the peer send us an invalid update.
+	ErrInvalidUpdate
+
+	// ErrInvalidCommitment indicates that the remote peer sent us an
+	// invalid commitment signature.
+	ErrInvalidCommitment
+
+	// ErrInvalidRevocation indicates that the remote peer send us an
+	// invalid revocation message.
+	ErrInvalidRevocation
+)
+
+// LinkFailureError encapsulates an error that will make us fail the current
+// link. It contains the necessary information needed to determine if we should
+// force close the channel in the process, and if any error data should be sent
+// to the peer.
+type LinkFailureError struct {
+	// code is the type of error this LinkFailureError encapsulates.
+	code errorCode
+
+	// ForceClose indicates whether we should force close the channel
+	// because of this error.
+	ForceClose bool
+
+	// SendData is a byte slice that will be sent to the peer. If nil a
+	// generic error will be sent.
+	SendData []byte
+}
+
+// A compile time check to ensure LinkFailureError implements the error
+// interface.
+var _ error = (*LinkFailureError)(nil)
+
+// Error returns a generic error for the LinkFailureError.
+//
+// NOTE: Part of the error interface.
+func (e LinkFailureError) Error() string {
+	switch e.code {
+	case ErrInternalError:
+		return "internal error"
+	case ErrRemoteError:
+		return "remote error"
+	case ErrSyncError:
+		return "sync error"
+	case ErrInvalidUpdate:
+		return "invalid update"
+	case ErrInvalidCommitment:
+		return "invalid commitment"
+	case ErrInvalidRevocation:
+		return "invalid revocation"
+	default:
+		return "unknown error"
+	}
+}
+
+// ShouldSendToPeer indicates whether we should send an error to the peer if
+// the link fails with this LinkFailureError.
+func (e LinkFailureError) ShouldSendToPeer() bool {
+	switch e.code {
+	// If the failure is a result of the peer sending us an error, we don't
+	// have to respond with one.
+	case ErrRemoteError:
+		return false
+
+	// In all other cases we will attempt to send our peer an error message.
+	default:
+		return true
+	}
+}

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -506,12 +506,6 @@ func (s *mockServer) PubKey() [33]byte {
 	return s.id
 }
 
-func (s *mockServer) Disconnect(reason error) {
-	fmt.Printf("server %v disconnected due to %v\n", s.name, reason)
-
-	s.t.Fatalf("server %v was disconnected: %v", s.name, reason)
-}
-
 func (s *mockServer) WipeChannel(*wire.OutPoint) error {
 	return nil
 }

--- a/lnd.go
+++ b/lnd.go
@@ -118,7 +118,7 @@ func lndMain() error {
 		network = "mainnet"
 
 	case cfg.Bitcoin.SimNet:
-		network = "simmnet"
+		network = "simnet"
 
 	case cfg.Bitcoin.RegTest:
 		network = "regtest"

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -7127,20 +7127,9 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	nodes = []*lntest.HarnessNode{net.Alice}
 	err = lntest.WaitPredicate(func() bool {
 		return assertNumActiveHtlcs(nodes, 0)
-	}, time.Second*8)
+	}, time.Second*15)
 	if err != nil {
-		// It may be the case that due to a race, Bob's sweeping
-		// transaction hasn't yet been confirmed, so we'll mine another
-		// block to nudge it in. If after this it still Alice will has
-		// an HTLC, then it's actually a test failure.
-		if _, err := net.Miner.Node.Generate(1); err != nil {
-			t.Fatalf("unable to generate block: %v", err)
-		}
-		if err = lntest.WaitPredicate(func() bool {
-			return assertNumActiveHtlcs(nodes, 0)
-		}, time.Second*8); err != nil {
-			t.Fatalf("alice's channel still has active htlc's")
-		}
+		t.Fatalf("alice's channel still has active htlc's")
 	}
 
 	// Now we'll check Bob's pending channel report. Since this was Carol's

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -623,7 +623,7 @@ func testBasicChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	timeout := time.Duration(time.Second * 5)
 	ctxb := context.Background()
 
-	chanAmt := maxFundingAmount
+	chanAmt := maxBtcFundingAmount
 	pushAmt := btcutil.Amount(100000)
 
 	// First establish a channel with a capacity of 0.5 BTC between Alice
@@ -688,7 +688,7 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	bobUpdates, bQuit := subscribeGraphNotifications(t, ctxb, net.Bob)
 	defer close(bQuit)
 
-	chanAmt := maxFundingAmount
+	chanAmt := maxBtcFundingAmount
 	pushAmt := btcutil.Amount(100000)
 
 	// Create a channel Alice->Bob.
@@ -1057,7 +1057,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Create a new channel that requires 1 confs before it's considered
 	// open, then broadcast the funding transaction
-	chanAmt := maxFundingAmount
+	chanAmt := maxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
 	ctxt, _ := context.WithTimeout(ctxb, timeout)
 	pendingUpdate, err := net.OpenPendingChannel(ctxt, net.Alice, net.Bob,
@@ -1193,7 +1193,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	// Check existing connection.
 	assertNumConnections(ctxb, t, net.Alice, net.Bob, 1)
 
-	chanAmt := maxFundingAmount
+	chanAmt := maxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
 
 	timeout := time.Duration(time.Second * 10)
@@ -1329,7 +1329,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxb := context.Background()
 
-	chanAmt := maxFundingAmount
+	chanAmt := maxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
 
 	timeout := time.Duration(time.Second * 10)
@@ -1463,7 +1463,7 @@ func testChannelBalance(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel with 0.16 BTC between Alice and Bob, ensuring the
 	// channel has been opened properly.
-	amount := maxFundingAmount
+	amount := maxBtcFundingAmount
 	ctx, _ := context.WithTimeout(context.Background(), timeout)
 
 	// Creates a helper closure to be used below which asserts the proper
@@ -3848,7 +3848,7 @@ func testBasicChannelCreation(net *lntest.NetworkHarness, t *harnessTest) {
 	const (
 		numChannels = 2
 		timeout     = time.Duration(time.Second * 5)
-		amount      = maxFundingAmount
+		amount      = maxBtcFundingAmount
 	)
 
 	// Open the channel between Alice and Bob, asserting that the
@@ -3874,7 +3874,7 @@ func testBasicChannelCreation(net *lntest.NetworkHarness, t *harnessTest) {
 // exists and works properly.
 func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	maxPendingChannels := defaultMaxPendingChannels + 1
-	amount := maxFundingAmount
+	amount := maxBtcFundingAmount
 
 	timeout := time.Duration(time.Second * 10)
 	ctx, _ := context.WithTimeout(context.Background(), timeout)
@@ -4075,7 +4075,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxb := context.Background()
 	const (
 		timeout     = time.Duration(time.Second * 10)
-		chanAmt     = maxFundingAmount
+		chanAmt     = maxBtcFundingAmount
 		paymentAmt  = 10000
 		numInvoices = 6
 	)
@@ -4321,7 +4321,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	ctxb := context.Background()
 	const (
 		timeout     = time.Duration(time.Second * 10)
-		chanAmt     = maxFundingAmount
+		chanAmt     = maxBtcFundingAmount
 		paymentAmt  = 10000
 		numInvoices = 6
 	)
@@ -4553,7 +4553,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	ctxb := context.Background()
 	const (
 		timeout     = time.Duration(time.Second * 10)
-		chanAmt     = maxFundingAmount
+		chanAmt     = maxBtcFundingAmount
 		pushAmt     = 200000
 		paymentAmt  = 10000
 		numInvoices = 6
@@ -4590,7 +4590,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// In order to test Dave's response to an uncooperative channel closure
 	// by Carol, we'll first open up a channel between them with a
-	// maxFundingAmount (2^24) satoshis value.
+	// maxBtcFundingAmount (2^24) satoshis value.
 	ctxt, _ := context.WithTimeout(ctxb, timeout)
 	chanPoint := openChannelAndAssert(
 		ctxt, t, net, dave, carol, chanAmt, pushAmt, false,
@@ -4985,7 +4985,7 @@ func testHtlcErrorPropagation(net *lntest.NetworkHarness, t *harnessTest) {
 	timeout := time.Duration(time.Second * 15)
 	ctxb := context.Background()
 
-	const chanAmt = maxFundingAmount
+	const chanAmt = maxBtcFundingAmount
 
 	// First establish a channel with a capacity of 0.5 BTC between Alice
 	// and Bob.
@@ -5034,7 +5034,7 @@ func testHtlcErrorPropagation(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect bob to carol: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, timeout)
-	const bobChanAmt = maxFundingAmount
+	const bobChanAmt = maxBtcFundingAmount
 	chanPointBob := openChannelAndAssert(
 		ctxt, t, net, net.Bob, carol, chanAmt, 0, false,
 	)
@@ -5315,7 +5315,7 @@ func subscribeGraphNotifications(t *harnessTest, ctxb context.Context,
 }
 
 func testGraphTopologyNotifications(net *lntest.NetworkHarness, t *harnessTest) {
-	const chanAmt = maxFundingAmount
+	const chanAmt = maxBtcFundingAmount
 	timeout := time.Duration(time.Second * 5)
 	ctxb := context.Background()
 
@@ -5591,7 +5591,7 @@ func testNodeSignVerify(net *lntest.NetworkHarness, t *harnessTest) {
 	timeout := time.Duration(time.Second * 15)
 	ctxb := context.Background()
 
-	chanAmt := maxFundingAmount
+	chanAmt := maxBtcFundingAmount
 	pushAmt := btcutil.Amount(100000)
 
 	// Create a channel between alice and bob.

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -4060,10 +4060,11 @@ func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxb := context.Background()
 	const (
 		timeout    = time.Duration(time.Second * 10)
-		chanAmt    = maxFundingAmount
 		paymentAmt = 10000
 		defaultCSV = 4
 	)
+
+	chanAmt := maxFundingAmount
 
 	// We'll introduce Carol, which will settle any incoming invoice with a
 	// totally unrelated preimage.

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -998,8 +998,8 @@ func (n *NetworkHarness) WaitForChannelClose(ctx context.Context,
 	}
 }
 
-// AssertChannelExists asserts that an active channel identified by
-// channelPoint is known to exist from the point-of-view of node..
+// AssertChannelExists asserts that an active channel identified by the
+// specified channel point exists from the point-of-view of the node.
 func (n *NetworkHarness) AssertChannelExists(ctx context.Context,
 	node *HarnessNode, chanPoint *wire.OutPoint) error {
 
@@ -1015,7 +1015,7 @@ func (n *NetworkHarness) AssertChannelExists(ctx context.Context,
 
 		for _, channel := range resp.Channels {
 			if channel.ChannelPoint == chanPoint.String() {
-				return true
+				return channel.Active
 			}
 
 		}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1773,9 +1773,12 @@ func (lc *LightningChannel) restoreStateLogs(
 					"%v vs %v", payDesc.HtlcIndex,
 					lc.localUpdateLog.htlcCounter))
 			}
+
 			lc.localUpdateLog.appendHtlc(payDesc)
 		} else {
 			lc.localUpdateLog.appendUpdate(payDesc)
+
+			lc.remoteUpdateLog.markHtlcModified(payDesc.ParentIndex)
 		}
 	}
 

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5580,13 +5580,6 @@ func (lc *LightningChannel) CompleteCooperativeClose(localSig, remoteSig []byte,
 	return closeTx, ourBalance, nil
 }
 
-// DeleteState deletes all state concerning the channel from the underlying
-// database, only leaving a small summary describing metadata of the
-// channel's lifetime.
-func (lc *LightningChannel) DeleteState(c *channeldb.ChannelCloseSummary) error {
-	return lc.channelState.CloseChannel(c)
-}
-
 // AvailableBalance returns the current available balance within the channel.
 // By available balance, we mean that if at this very instance s new commitment
 // were to be created which evals all the log entries, what would our available

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1165,6 +1165,9 @@ func (u *updateLog) removeHtlc(i uint64) {
 	u.Remove(entry)
 	delete(u.htlcIndex, i)
 
+	delete(u.modifiedHtlcs, i)
+}
+
 // htlcHasModification returns true if the HTLC identified by the passed index
 // has a pending modification within the log.
 func (u *updateLog) htlcHasModification(i uint64) bool {

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5896,6 +5896,16 @@ func (lc *LightningChannel) State() *channeldb.OpenChannel {
 	return lc.channelState
 }
 
+// MarkCommitmentBroadcasted marks the channel as a commitment transaction has
+// been broadcast, either our own or the remote, and we should watch the chain
+// for it to confirm before taking any further action.
+func (lc *LightningChannel) MarkCommitmentBroadcasted() error {
+	lc.Lock()
+	defer lc.Unlock()
+
+	return lc.channelState.MarkCommitmentBroadcasted()
+}
+
 // ActiveHtlcs returns a slice of HTLC's which are currently active on *both*
 // commitment transactions.
 func (lc *LightningChannel) ActiveHtlcs() []channeldb.HTLC {

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -5505,3 +5505,194 @@ func TestDuplicateSettleRejection(t *testing.T) {
 		t.Fatalf("unable to recv htlc cancel: %v", err)
 	}
 }
+
+// TestChannelRestoreCommitHeight tests that the local and remote commit
+// heights of HTLCs are set correctly across restores.
+func TestChannelRestoreCommitHeight(t *testing.T) {
+	t.Parallel()
+
+	aliceChannel, bobChannel, cleanUp, err := CreateTestChannels()
+	if err != nil {
+		t.Fatalf("unable to create test channels: %v", err)
+	}
+	defer cleanUp()
+
+	// helper method to check add heights of the htlcs found in the given
+	// log after a restore.
+	restoreAndAssertCommitHeights := func(t *testing.T,
+		channel *LightningChannel, remoteLog bool, htlcIndex uint64,
+		expLocal, expRemote uint64) *LightningChannel {
+
+		channel.Stop()
+		newChannel, err := NewLightningChannel(
+			channel.Signer, nil, channel.channelState,
+		)
+		if err != nil {
+			t.Fatalf("unable to create new channel: %v", err)
+		}
+
+		var pd *PaymentDescriptor
+		if remoteLog {
+			if newChannel.localUpdateLog.lookupHtlc(htlcIndex) != nil {
+				t.Fatalf("htlc found in wrong log")
+			}
+			pd = newChannel.remoteUpdateLog.lookupHtlc(htlcIndex)
+
+		} else {
+			if newChannel.remoteUpdateLog.lookupHtlc(htlcIndex) != nil {
+				t.Fatalf("htlc found in wrong log")
+			}
+			pd = newChannel.localUpdateLog.lookupHtlc(htlcIndex)
+		}
+		if pd == nil {
+			t.Fatalf("htlc not found in log")
+		}
+
+		if pd.addCommitHeightLocal != expLocal {
+			t.Fatalf("expected local add height to be %d, was %d",
+				expLocal, pd.addCommitHeightLocal)
+		}
+		if pd.addCommitHeightRemote != expRemote {
+			t.Fatalf("expected remote add height to be %d, was %d",
+				expRemote, pd.addCommitHeightRemote)
+		}
+		return newChannel
+	}
+
+	// We'll send an HtLC from Alice to Bob.
+	htlcAmount := lnwire.NewMSatFromSatoshis(100000000)
+	htlcAlice, _ := createHTLC(0, htlcAmount)
+	if _, err := aliceChannel.AddHTLC(htlcAlice, nil); err != nil {
+		t.Fatalf("alice unable to add htlc: %v", err)
+	}
+	if _, err := bobChannel.ReceiveHTLC(htlcAlice); err != nil {
+		t.Fatalf("bob unable to recv add htlc: %v", err)
+	}
+
+	// Let Alice sign a new state, which will include the HTLC just sent.
+	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	if err != nil {
+		t.Fatalf("unable to sign commitment: %v", err)
+	}
+
+	// The HTLC should only be on the pending remote commitment, so the
+	// only the remote add height should be set during a restore.
+	aliceChannel = restoreAndAssertCommitHeights(t, aliceChannel, false,
+		0, 0, 1)
+
+	// Bob receives this commitment signature, and revokes his old state.
+	err = bobChannel.ReceiveNewCommitment(aliceSig, aliceHtlcSigs)
+	if err != nil {
+		t.Fatalf("unable to receive commitment: %v", err)
+	}
+	bobRevocation, _, err := bobChannel.RevokeCurrentCommitment()
+	if err != nil {
+		t.Fatalf("unable to revoke commitment: %v", err)
+	}
+
+	// Now the HTLC is locked into Bob's commitment, a restoration should
+	// set only the local commit height, as it is not locked into Alice's
+	// yet.
+	bobChannel = restoreAndAssertCommitHeights(t, bobChannel, true, 0, 1, 0)
+
+	// Alice receives the revocation, ACKing her pending commitment.
+	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	if err != nil {
+		t.Fatalf("unable to recive revocation: %v", err)
+	}
+
+	// However, the HTLC is still not locked into her local commitment, so
+	// the local add height should still be 0 after a restoration.
+	aliceChannel = restoreAndAssertCommitHeights(t, aliceChannel, false,
+		0, 0, 1)
+
+	// Now let Bob send the commitment signature making the HTLC lock in on
+	// Alice's commitment.
+	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	if err != nil {
+		t.Fatalf("unable to sign commitment: %v", err)
+	}
+
+	// At this stage Bob has a pending remote commitment. Make sure
+	// restoring at this stage correcly restores the HTLC add commit
+	// heights.
+	bobChannel = restoreAndAssertCommitHeights(t, bobChannel, true, 0, 1, 1)
+
+	err = aliceChannel.ReceiveNewCommitment(bobSig, bobHtlcSigs)
+	if err != nil {
+		t.Fatalf("unable to receive commitment: %v", err)
+	}
+	aliceRevocation, _, err := aliceChannel.RevokeCurrentCommitment()
+	if err != nil {
+		t.Fatalf("unable to revoke commitment: %v", err)
+	}
+
+	// Now both the local and remote add heights should be properly set.
+	aliceChannel = restoreAndAssertCommitHeights(t, aliceChannel, false,
+		0, 1, 1)
+
+	_, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
+		t.Fatalf("unable to recive revocation: %v", err)
+	}
+
+	// Alice ACKing Bob's pending commitment shouldn't change the heights
+	// restored.
+	bobChannel = restoreAndAssertCommitHeights(t, bobChannel, true, 0, 1, 1)
+
+	// Send andother HTLC from Alice to Bob, to test whether already
+	// existing HTLCs (the HTLC with index 0) keep getting the add heights
+	// restored properly.
+	htlcAlice, _ = createHTLC(1, htlcAmount)
+	if _, err := aliceChannel.AddHTLC(htlcAlice, nil); err != nil {
+		t.Fatalf("alice unable to add htlc: %v", err)
+	}
+	if _, err := bobChannel.ReceiveHTLC(htlcAlice); err != nil {
+		t.Fatalf("bob unable to recv add htlc: %v", err)
+	}
+
+	// Send a new signature from Alice to Bob, making Alice have a pending
+	// remote commitment.
+	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	if err != nil {
+		t.Fatalf("unable to sign commitment: %v", err)
+	}
+
+	// A restoration should keep the add heights iof the first HTLC, and
+	// the new HTLC should have a remote add height 2.
+	aliceChannel = restoreAndAssertCommitHeights(t, aliceChannel, false,
+		0, 1, 1)
+	aliceChannel = restoreAndAssertCommitHeights(t, aliceChannel, false,
+		1, 0, 2)
+
+	err = bobChannel.ReceiveNewCommitment(aliceSig, aliceHtlcSigs)
+	if err != nil {
+		t.Fatalf("unable to receive commitment: %v", err)
+	}
+	bobRevocation, _, err = bobChannel.RevokeCurrentCommitment()
+	if err != nil {
+		t.Fatalf("unable to revoke commitment: %v", err)
+	}
+
+	// Since Bob just revoked another commitment, a restoration should
+	// increase the add height of the firt HTLC to 2, as we only keep the
+	// last unrevoked commitment. The new HTLC will also have a local add
+	// height of 2.
+	bobChannel = restoreAndAssertCommitHeights(t, bobChannel, true, 0, 2, 1)
+	bobChannel = restoreAndAssertCommitHeights(t, bobChannel, true, 1, 2, 0)
+
+	// Sign a new state for Alice, making Bob have a pending remote
+	// commitment.
+	bobSig, bobHtlcSigs, err = bobChannel.SignNextCommitment()
+	if err != nil {
+		t.Fatalf("unable to sign commitment: %v", err)
+	}
+
+	// The signing of a new commitment for Alice should have given the new
+	// HTLC an add height.
+	bobChannel = restoreAndAssertCommitHeights(t, bobChannel, true, 0, 2, 1)
+	bobChannel = restoreAndAssertCommitHeights(t, bobChannel, true, 1, 2, 2)
+
+	aliceChannel.Stop()
+	bobChannel.Stop()
+}

--- a/release.sh
+++ b/release.sh
@@ -26,6 +26,7 @@ SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 l
 # Use the first element of $GOPATH in the case where GOPATH is a list
 # (something that is totally allowed).
 GPATH=$(echo $GOPATH | cut -f1 -d:)
+COMMITFLAGS="-X main.Commit=$(git rev-parse HEAD)"
 
 for i in $SYS; do
     OS=$(echo $i | cut -f1 -d-)
@@ -33,8 +34,8 @@ for i in $SYS; do
     mkdir $PACKAGE-$i-$TAG
     cd $PACKAGE-$i-$TAG
     echo "Building:" $OS $ARCH
-    env GOOS=$OS GOARCH=$ARCH go build -v github.com/lightningnetwork/lnd
-    env GOOS=$OS GOARCH=$ARCH go build -v github.com/lightningnetwork/lnd/cmd/lncli
+    env GOOS=$OS GOARCH=$ARCH go build -v -ldflags "$COMMITFLAGS" github.com/lightningnetwork/lnd
+    env GOOS=$OS GOARCH=$ARCH go build -v -ldflags "$COMMITFLAGS" github.com/lightningnetwork/lnd/cmd/lncli
     cd ..
     if [[ $OS = "windows" ]]; then
 	zip -r $PACKAGE-$i-$TAG.zip $PACKAGE-$i-$TAG

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -39,7 +39,23 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	// maxBtcPaymentMSat is the maximum allowed Bitcoin payment currently
+	// permitted as defined in BOLT-0002.
+	maxBtcPaymentMSat = lnwire.MilliSatoshi(math.MaxUint32)
+
+	// maxLtcPaymentMSat is the maximum allowed Litecoin payment currently
+	// permitted.
+	maxLtcPaymentMSat = lnwire.MilliSatoshi(math.MaxUint32) *
+		btcToLtcConversionRate
+)
+
 var (
+	// maxPaymentMSat is the maximum allowed payment currently permitted as
+	// defined in BOLT-002. This value depends on which chain is active.
+	// It is set to the value under the Bitcoin chain as default.
+	maxPaymentMSat = maxBtcPaymentMSat
+
 	defaultAccount uint32 = waddrmgr.DefaultAccountNum
 
 	// readPermissions is a slice of all entities that allow read
@@ -298,12 +314,6 @@ var (
 			Action: "read",
 		}},
 	}
-)
-
-const (
-	// maxPaymentMSat is the maximum allowed payment permitted currently as
-	// defined in BOLT-0002.
-	maxPaymentMSat = lnwire.MilliSatoshi(math.MaxUint32)
 )
 
 // rpcServer is a gRPC, RPC front end to the lnd daemon.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1455,6 +1455,10 @@ func (r *rpcServer) PendingChannels(ctx context.Context,
 
 		// If the channel was closed cooperatively, then we'll only
 		// need to tack on the closing txid.
+		// TODO(halseth): remove. After recent changes, a coop closed
+		// channel should never be in the "pending close" state.
+		// Keeping for now to let someone that upgraded in the middle
+		// of a close let their closing tx confirm.
 		case channeldb.CooperativeClose:
 			resp.PendingClosingChannels = append(
 				resp.PendingClosingChannels,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -44,7 +44,7 @@ const (
 	// permitted as defined in BOLT-0002.
 	maxBtcPaymentMSat = lnwire.MilliSatoshi(math.MaxUint32)
 
-	// maxMonaPaymentMSat is the maximum allowed Litecoin payment currently
+	// maxMonaPaymentMSat is the maximum allowed Monacoin payment currently
 	// permitted.
 	maxMonaPaymentMSat = lnwire.MilliSatoshi(math.MaxUint32) *
 		btcToMonaConversionRate

--- a/version.go
+++ b/version.go
@@ -19,7 +19,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 4
-	appPatch uint = 1
+	appPatch uint = 2
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
今回は日本語で書きます。

〇手順

Wakiyamap/lndをfork
forkした自分のリポジトリをcloneしたローカルリポジトリ内で
remote add lightningnetwork lightningnetwork/lnd
fetch lightningnetwork
merge lightningnetwork/master
を実行しようとすると
```chainregistry.go```
```chancloser.go```
```config.go```
```release.sh```
がconflictしたので修正
修正の中で以下のような変数名の置き換えをしたので
```maxLtcFundingAmount -> maxMonaFundingAmount```
```maxLtcPaymentMSat -> maxMonaPaymentMSat```
これらの変数を含む以下のファイルでも同様な置き換えを実行
```fundingmanager.go```
```rpcserver.go```
liteとltcの文字が追加されていないことを確認。
また今回の変更でチャネルにデポジット出来る量とペイメント出来る量がLTCはBTCの60倍となる変更が加えられていますが、その数字は変えずに60のままにしています。

以上です。